### PR TITLE
fixed memory leak

### DIFF
--- a/public/javascript/zebra_datepicker.src.js
+++ b/public/javascript/zebra_datepicker.src.js
@@ -1123,7 +1123,10 @@
             }
 
             // update icon/date picker position on resize and/or changing orientation
-            $(window).bind('resize.Zebra_DatePicker_' + uniqueid + ', orientationchange.Zebra_DatePicker_' + uniqueid, function() {
+            var resizeAndOrientationChangeHandler = function () {
+
+                if (!resizeInProgress) wasVisibleBeforeResize = datepicker.hasClass('dp_visible');
+                resizeInProgress = true;
 
                 // hide the date picker
                 plugin.hide();
@@ -1142,11 +1145,17 @@
                           // update the date picker
                           plugin.update();
 
+                          if (wasVisibleBeforeResize) plugin.show();
+                          
+                          resizeInProgress = false;
+
                       }, 100);
 
                 }
 
-            });
+            };
+            $(window).bind('resize.Zebra_DatePicker_' + uniqueid, resizeAndOrientationChangeHandler);
+            $(window).bind('orientationchange.Zebra_DatePicker_' + uniqueid, resizeAndOrientationChangeHandler);
 
             // generate the container that will hold everything
             var html = '' +
@@ -1416,7 +1425,7 @@
             if (!plugin.settings.always_visible) {
 
                 //whenever anything is clicked on the page
-                $(document).bind('mousedown.Zebra_DatePicker_' + uniqueid + ', touchstart.Zebra_DatePicker_' + uniqueid, function(e) {
+                var mouseDownAndTouchStartHandler = function (e) {
 
                     // if the date picker is visible
                     if (datepicker.hasClass('dp_visible')) {
@@ -1431,7 +1440,9 @@
 
                     }
 
-                });
+                };
+                $(document).bind('mousedown.Zebra_DatePicker_' + uniqueid, mouseDownAndTouchStartHandler);
+                $(document).bind('touchstart.Zebra_DatePicker_' + uniqueid, mouseDownAndTouchStartHandler);
 
                 //whenever a key is pressed on the page
                 $(document).bind('keyup.Zebra_DatePicker_' + uniqueid, function(e) {
@@ -1485,6 +1496,7 @@
             // remove associated event handlers from the document
             $(document).unbind('keyup.Zebra_DatePicker_' + uniqueid);
             $(document).unbind('mousedown.Zebra_DatePicker_' + uniqueid);
+            $(document).unbind('touchstart.Zebra_DatePicker_' + uniqueid);
             $(window).unbind('resize.Zebra_DatePicker_' + uniqueid);
             $(window).unbind('orientationchange.Zebra_DatePicker_' + uniqueid);
 


### PR DESCRIPTION
As I wrote in [this](https://github.com/stefangabos/Zebra_Datepicker/issues/68) issue it is better to register an event handler for multiple events separately than registering it in one call because when unbind is called jquery does not find the event handler because of the comma at the end of the event name.
In the fix I register the event handler for the events separately and so the unbinding in the destroy() method is successful and the leak goes away.